### PR TITLE
Add devcontainer config

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,20 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/javascript-node
+{
+	"name": "Node.js",
+	"image": "mcr.microsoft.com/devcontainers/javascript-node:0-16-bullseye",
+	// Features to add to the dev container. More info: https://containers.dev/features.
+	"features": {
+		"ghcr.io/carlosdp/devcontainer-features/foundry:latest": {}
+	},
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	"forwardPorts": [
+		3000
+	],
+	// Use 'postCreateCommand' to run commands after the container is created.
+	"postCreateCommand": "yarn install && yarn prepare"
+	// Configure tool-specific properties.
+	// "customizations": {},
+	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
+	// "remoteUser": "root"
+}

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "packages/client"
   ],
   "scripts": {
+    "prepare": "yarn workspace contracts run prepare",
     "dev": "run-pty % yarn dev:node % yarn dev:client % yarn dev:contracts",
     "dev:client": "yarn workspace client run dev",
     "dev:node": "yarn workspace contracts run devnode",

--- a/packages/client/src/config.ts
+++ b/packages/client/src/config.ts
@@ -9,8 +9,8 @@ export const config: SetupContractConfig = {
     syncInterval: 5000,
   },
   provider: {
-    jsonRpcUrl: params.get("rpc") ?? "http://localhost:8545",
-    wsRpcUrl: params.get("wsRpc") ?? "ws://localhost:8545",
+    jsonRpcUrl: params.get("rpc") ?? `http://${window.location.host}/rpc`,
+    wsRpcUrl: params.get("wsRpc") ?? `ws://${window.location.host}/rpc`,
     chainId: Number(params.get("chainId")) || 31337,
   },
   privateKey: Wallet.createRandom().privateKey,

--- a/packages/client/vite.config.ts
+++ b/packages/client/vite.config.ts
@@ -5,6 +5,13 @@ export default defineConfig({
     fs: {
       strict: false,
     },
+    proxy: {
+      '/rpc': {
+        target: 'http://localhost:8545/',
+        rewrite: () => '/',
+        ws: true,
+      },
+    },
   },
   optimizeDeps: {
     esbuildOptions: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1211,9 +1211,9 @@ doctrine@^3.0.0:
   dependencies:
     esutils "^2.0.2"
 
-"ds-test@git+https://github.com/dapphub/ds-test.git#9310e879db8ba3ea6d5c6489a579118fd264a3f5":
+"ds-test@https://github.com/dapphub/ds-test.git#9310e879db8ba3ea6d5c6489a579118fd264a3f5":
   version "0.0.0"
-  resolved "git+https://github.com/dapphub/ds-test.git#9310e879db8ba3ea6d5c6489a579118fd264a3f5"
+  resolved "https://github.com/dapphub/ds-test.git#9310e879db8ba3ea6d5c6489a579118fd264a3f5"
 
 "ds-test@https://github.com/dapphub/ds-test.git#c7a36fb236f298e04edf28e2fee385b80f53945f":
   version "0.0.0"
@@ -1684,13 +1684,13 @@ follow-redirects@^1.14.7:
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.2.tgz#b460864144ba63f2681096f274c4e57026da2c13"
   integrity sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==
 
-"forge-std@git+https://github.com/foundry-rs/forge-std.git#6b4ca42943f093642bac31783b08aa52a5a6ff64":
-  version "0.0.0"
-  resolved "git+https://github.com/foundry-rs/forge-std.git#6b4ca42943f093642bac31783b08aa52a5a6ff64"
-
 "forge-std@https://github.com/foundry-rs/forge-std.git#4d36e3f7e2168c8155c641eb0f80e85cd584bd1c":
   version "0.0.0"
   resolved "https://github.com/foundry-rs/forge-std.git#4d36e3f7e2168c8155c641eb0f80e85cd584bd1c"
+
+"forge-std@https://github.com/foundry-rs/forge-std.git#6b4ca42943f093642bac31783b08aa52a5a6ff64":
+  version "0.0.0"
+  resolved "https://github.com/foundry-rs/forge-std.git#6b4ca42943f093642bac31783b08aa52a5a6ff64"
 
 format@^0.2.0:
   version "0.2.2"
@@ -3002,9 +3002,9 @@ solidity-comments-extractor@^0.0.7:
   resolved "https://registry.yarnpkg.com/solidity-comments-extractor/-/solidity-comments-extractor-0.0.7.tgz#99d8f1361438f84019795d928b931f4e5c39ca19"
   integrity sha512-wciNMLg/Irp8OKGrh3S2tfvZiZ0NEyILfcRCXCD4mp7SgK/i9gzLfhY2hY7VMCQJ3kH9UB9BzNdibIVMchzyYw==
 
-"solmate@git+https://github.com/Rari-Capital/solmate.git#9cf1428245074e39090dceacb0c28b1f684f584c":
+"solmate@https://github.com/Rari-Capital/solmate.git#9cf1428245074e39090dceacb0c28b1f684f584c":
   version "6.5.0"
-  resolved "git+https://github.com/Rari-Capital/solmate.git#9cf1428245074e39090dceacb0c28b1f684f584c"
+  resolved "https://github.com/Rari-Capital/solmate.git#9cf1428245074e39090dceacb0c28b1f684f584c"
 
 source-map-js@^1.0.2:
   version "1.0.2"


### PR DESCRIPTION
Spoke to @alvrs about this earlier today. I've been using Microsoft's devcontainers spec as my primary development environment for a few weeks, and can vouch that it's gotten super solid, especially when paired with VSCode and the Microsoft provided plugins.

I think adding devcontainer support to Mud templates could be a great 90/10 solution for vastly decreasing friction in getting someone to try out that "5-20 min demo" of building something in Mud, cause one click sets up the entire environment for them! The primary documentation can even just prompt the user to open the project in a Github Codespace and they can get started literally in seconds (no waiting for yarn install or anything!).

This PR just quickly adds a devcontainer config to this repo, and does some work to make the project work in a container-based dev environment (with no breaking changes):

- Add .devcontainer.json
- Use a "devcontainer feature" [I made](https://github.com/carlosdp/devcontainer-features) to add Foundry to the container image
- Add some config to the Vite dev server so that it proxies the Anvil RPC (because the dev server might not be at `localhost` depending on where the container is run

Next step would be to add a README and go for "how do we give as few steps as possible to the quickest 'aha' moment" for developers trying Mud!